### PR TITLE
WildFly 10 serialization changes

### DIFF
--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/Profile.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/Profile.java
@@ -18,6 +18,7 @@
  */
 package org.soulwing.cas.extension;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -38,9 +39,11 @@ import org.soulwing.cas.service.Configuration;
  *
  * @author Carl Harris
  */
-public class Profile implements Configuration {
+public class Profile implements Configuration, Serializable {
 
-  private final InjectedValue<SSLContext> sslContext =
+  private static final long serialVersionUID = 6170159365985362873L;
+
+  private final transient InjectedValue<SSLContext> sslContext =
       new InjectedValue<>();
   
   private final Map<String, List<String>> allowedProxyChains = 

--- a/cas-subsystem/src/main/java/org/soulwing/cas/service/JasigAuthenticator.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/service/JasigAuthenticator.java
@@ -20,6 +20,7 @@ package org.soulwing.cas.service;
 
 import static org.soulwing.cas.service.ServiceLogger.LOGGER;
 
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
@@ -34,13 +35,15 @@ import org.soulwing.cas.api.IdentityAssertion;
  *
  * @author Carl Harris
  */
-public class JasigAuthenticator implements Authenticator {
+public class JasigAuthenticator implements Authenticator, Serializable {
+
+  private static final long serialVersionUID = 364417311301329226L;
 
   public static final String LOGIN_PATH = "login";
   public static final String LOGOUT_PATH = "logout";
 
   private final Configuration config;
-  private final TicketValidator validator;
+  private final transient TicketValidator validator;
   
   /**
    * Constructs a new instance.

--- a/cas-subsystem/src/main/java/org/soulwing/cas/service/JasigIdentityAssertion.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/service/JasigIdentityAssertion.java
@@ -18,6 +18,7 @@
  */
 package org.soulwing.cas.service;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 
@@ -31,7 +32,9 @@ import org.soulwing.cas.api.UserPrincipal;
  *
  * @author Carl Harris
  */
-class JasigIdentityAssertion implements IdentityAssertion {
+class JasigIdentityAssertion implements IdentityAssertion, Serializable {
+
+  private static final long serialVersionUID = 309684827031727467L;
 
   private final Authenticator authenticator;
   private final Assertion delegate;

--- a/cas-subsystem/src/main/java/org/soulwing/cas/service/TransformingMap.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/service/TransformingMap.java
@@ -18,6 +18,7 @@
  */
 package org.soulwing.cas.service;
 
+import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -40,7 +41,9 @@ import org.soulwing.cas.api.Transformer;
  *
  * @author Carl Harris
  */
-class TransformingMap extends AbstractMap<String, Object> {
+class TransformingMap extends AbstractMap<String, Object> implements Serializable {
+
+  private static final long serialVersionUID = -217419703730591133L;
 
   private final Lock lock = new ReentrantLock();
   private final Map<String, Object> delegate;

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/IdentityAssertionCredential.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/IdentityAssertionCredential.java
@@ -20,6 +20,8 @@ package org.soulwing.cas.undertow;
 
 import io.undertow.security.idm.Credential;
 
+import java.io.Serializable;
+
 import org.soulwing.cas.api.IdentityAssertion;
 import org.soulwing.cas.jaas.IdentityAssertionHolder;
 
@@ -29,7 +31,9 @@ import org.soulwing.cas.jaas.IdentityAssertionHolder;
  * @author Carl Harris
  */
 public class IdentityAssertionCredential 
-    implements Credential, IdentityAssertionHolder {
+    implements Credential, IdentityAssertionHolder, Serializable {
+
+  private static final long serialVersionUID = -7355252883140571658L;
 
   private final IdentityAssertion identityAssertion;
 


### PR DESCRIPTION
This change resolves a series of NotSerializableExceptions I encountered while using the extension in a WF10 cluster. The changes add Serializable to the affected classes and mark a couple of fields as transient. This may or may not be the best approach, but, with these changes, the extension appears to perform as expected.