### PR TITLE
Switch repository URL of jboss from http to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
   <repositories>
     <repository> 
       <id>jboss</id>
-      <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
     </repository>
   </repositories>
   <modules>


### PR DESCRIPTION
Switching from http to https improves security a bit (while building)