### PR TITLE
Cookie switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ can also view the description of these attributes using the
 * *security-realm* -- (Wildfly 9 only) specifies the name of a Security Realm
   to use to obtain SSL truststore and/or keystore configuration to use when
   communicating with the CAS server
+* *cas-status-cookie-enabled* -- whether tracking of the login attempts is
+  enabled and restricted. If you exceed the maximum number of attempts
+  the user will see a HTTP status 403. Can be true (default) or false.
 
 ### Profile Sub-Resources
 

--- a/cas-subsystem/src/main/java/org/soulwing/cas/deployment/DeploymentAuthenticationService.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/deployment/DeploymentAuthenticationService.java
@@ -100,6 +100,9 @@ class DeploymentAuthenticationService
     }
     sb.append(proxyCallbackPath);
     return sb.toString();
-  }  
+  }
 
+  public Configuration getConfiguration() {
+    return profile.getValue();
+  }
 }

--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/Names.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/Names.java
@@ -66,6 +66,7 @@ public interface Names {
   String OPTIONS = "options";
   String OPTION = "option";
   String KEY = "key";
+  String CAS_STATUS_COOKIE_ENABLED = "cas-status-cookie-enabled";
   
   String AUTHENTICATION_SERVICE = "authentication-service";  
   String SERVLET_EXTENSION = "servlet-extension";

--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/Profile.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/Profile.java
@@ -79,7 +79,9 @@ public class Profile implements Configuration, Serializable {
   private long clockSkewTolerance;
   
   private boolean postAuthRedirect;
-    
+
+  private boolean casStatusCookieEnabled;
+
   /**
    * Gets the {@code sslContext} property.
    * @return property value
@@ -353,6 +355,21 @@ public class Profile implements Configuration, Serializable {
    */
   public void setPostAuthRedirect(boolean postAuthRedirect) {
     this.postAuthRedirect = postAuthRedirect;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isCasStatusCookieEnabled() {
+    return casStatusCookieEnabled;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public void setCasStatusCookieEnabled(boolean set) {
+    this.casStatusCookieEnabled = set;
   }
 
   /**

--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/Profile.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/Profile.java
@@ -402,14 +402,16 @@ public class Profile implements Configuration, Serializable {
         + " proxyCallbackPath=%s acceptAnyProxy=%s allowEmptyProxyChain=%s"
         + " allowedProxyChains=%s"
         + " renew=%s clockSkewTolerance=%d postAuthRedirect=%s"
-        + " securityRealm=%s hostnameVerifier=%s attributeTransformers=%s }",
+        + " securityRealm=%s hostnameVerifier=%s attributeTransformers=%s "
+        + " casStatuscasStatusCookieEnabled=%s }",
         protocol, encoding, serverUrl, serviceUrl, proxyCallbackEnabled, 
         proxyCallbackPath, acceptAnyProxy, allowEmptyProxyChain, 
         allowedProxyChains, renew, clockSkewTolerance, postAuthRedirect,
         securityRealm != null ? securityRealm : "(none)", 
         hostnameVerifier != null ? 
             hostnameVerifier.getClass().getSimpleName() : "(none)",
-        attributeTransformers);
+        attributeTransformers,
+        casStatusCookieEnabled);
   }
 
 }

--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/ProfileDefinition.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/ProfileDefinition.java
@@ -174,6 +174,16 @@ public class ProfileDefinition extends SimpleResourceDefinition {
 	                  AttributeAccess.Flag.STORAGE_CONFIGURATION)
 	              .build();
 
+  static final SimpleAttributeDefinition CAS_STATUS_COOKIE_ENABLED =
+          new SimpleAttributeDefinitionBuilder(Names.CAS_STATUS_COOKIE_ENABLED,
+                  ModelType.BOOLEAN)
+                  .setAllowExpression(true)
+                  .setRequired(false)
+                  .setDefaultValue(new ModelNode(true))
+                  .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES,
+                          AttributeAccess.Flag.STORAGE_CONFIGURATION)
+                  .build();
+
   public static final ProfileDefinition INSTANCE =
       new ProfileDefinition();
 
@@ -191,7 +201,8 @@ public class ProfileDefinition extends SimpleResourceDefinition {
       RENEW,
       CLOCK_SKEW_TOLERANCE,
       POST_AUTH_REDIRECT,
-      SECURITY_REALM
+      SECURITY_REALM,
+      CAS_STATUS_COOKIE_ENABLED
     };
   }
 

--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/ProfileReaderWriter.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/ProfileReaderWriter.java
@@ -52,7 +52,8 @@ public class ProfileReaderWriter extends AbstractResourceReaderWriter {
         ProfileDefinition.RENEW,
         ProfileDefinition.CLOCK_SKEW_TOLERANCE,
         ProfileDefinition.POST_AUTH_REDIRECT,
-        ProfileDefinition.SECURITY_REALM
+        ProfileDefinition.SECURITY_REALM,
+        ProfileDefinition.CAS_STATUS_COOKIE_ENABLED
     };
   }
   

--- a/cas-subsystem/src/main/java/org/soulwing/cas/extension/ProfileService.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/extension/ProfileService.java
@@ -168,7 +168,9 @@ public class ProfileService extends AbstractService<Profile> {
           .resolveModelAttribute(context, model).asLong());
       config.setPostAuthRedirect(ProfileDefinition.POST_AUTH_REDIRECT
           .resolveModelAttribute(context, model).asBoolean());
-      
+      config.setCasStatusCookieEnabled(ProfileDefinition.CAS_STATUS_COOKIE_ENABLED
+          .resolveModelAttribute(context, model).asBoolean());
+
       ModelNode securityRealm = ProfileDefinition.SECURITY_REALM
           .resolveModelAttribute(context, model);
       if (securityRealm.isDefined()) {

--- a/cas-subsystem/src/main/java/org/soulwing/cas/service/AuthenticationService.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/service/AuthenticationService.java
@@ -46,5 +46,10 @@ public interface AuthenticationService {
    * @return proxy callback response
    */
   ProxyCallbackResponse handleProxyCallback(String query);
-  
+
+  /**
+   * Returns the configuration for this authentication service.
+   * @return configuration instance
+   */
+  Configuration getConfiguration();
 }

--- a/cas-subsystem/src/main/java/org/soulwing/cas/service/Configuration.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/service/Configuration.java
@@ -126,7 +126,14 @@ public interface Configuration {
    * @return flag state
    */
   boolean isPostAuthRedirect();
-  
+
+  /**
+   * Gets a flag that indicates whether tracking the login attempts
+   * with the 'cas-status' cookie is enabled.
+   * @return flag state
+   */
+  boolean isCasStatusCookieEnabled();
+
   /**
    * Gets the SSL context to use in negotiations with the CAS server.
    * @return SSL context or {@code null} to indicate that the default SSL

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
@@ -27,7 +27,10 @@ import io.undertow.server.handlers.Cookie;
 import io.undertow.server.handlers.CookieImpl;
 import io.undertow.util.HttpString;
 
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.value.InjectedValue;
 import org.soulwing.cas.api.IdentityAssertion;
+import org.soulwing.cas.extension.Profile;
 import org.soulwing.cas.service.AuthenticationException;
 import org.soulwing.cas.service.Authenticator;
 import org.soulwing.cas.service.NoTicketException;
@@ -44,15 +47,17 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
   public static final String NOT_AUTHORIZED_MESSAGE = 
       "identity manager does not recognize user '%s'";
 
-  public static final String STATUS_COOKIE = "cas-status";
-
-  public static final int MAX_RETRIES = 2;
-
-  
-  
   private final String contextPath;
   private final CasAuthenticationService authenticationService;
-  
+  private final InjectedValue<Profile> profile =
+      new InjectedValue<>();
+
+  public Injector<Profile> getProfileInjector() {
+    return profile;
+  }
+
+  private CasStatusCookie casStatusCookie;
+
   /**
    * Constructs a new instance.
    * @param contextPath 
@@ -88,8 +93,8 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
           new IdentityAssertionCredential(assertion);
       
       Account account = authorize(credential, securityContext);
-      
-      resetRetryCount(exchange);
+
+      casStatusCookie.resetRetryCount(exchange);
       
       exchange.putAttachment(CasAttachments.CREDENTIAL_KEY, credential);
       if (authenticator.isPostAuthRedirect()) {
@@ -131,15 +136,15 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
         exchange.getAttachment(CasAttachments.AUTH_FAILED_KEY);
     if (failedStatus != null) {
       exchange.removeAttachment(CasAttachments.AUTH_FAILED_KEY);
-      resetRetryCount(exchange);
+      casStatusCookie.resetRetryCount(exchange);
       return new ChallengeResult(false, failedStatus);
     }
         
-    if (getRetryCount(exchange) >= MAX_RETRIES) {
+    if (casStatusCookie.isRetryCountExceeded(exchange)) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("authentication failed: too many retries");
       }
-      resetRetryCount(exchange);
+      casStatusCookie.resetRetryCount(exchange);
       return new ChallengeResult(false, 401);
     }
     
@@ -157,62 +162,6 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
         HttpString.tryFromString("Location"), url);
     
     return new ChallengeResult(true, 302);
-  }
-
-  /**
-   * Gets the authentication retry count from a session cookie.
-   * @param exchange subject exchange
-   * @return current retry count
-   */
-  private int getRetryCount(HttpServerExchange exchange) {
-    int retries = 0;
-    
-    Cookie cookie = exchange.getRequestCookies().get(STATUS_COOKIE);
-    if (cookie == null) {
-      cookie = newCookie();
-    }
-    else {
-      try {
-        String value = cookie.getValue();
-        retries = Integer.parseInt(value) + 1;
-        if (retries < 0 || retries > MAX_RETRIES) {
-          retries = MAX_RETRIES;
-        }
-      }
-      catch (NumberFormatException ex) {
-        retries = MAX_RETRIES;
-      }
-      finally {
-        cookie.setValue(Integer.toString(retries));
-      }
-    }
-
-    cookie.setHttpOnly(true);
-    cookie.setSecure(true);
-    exchange.getResponseCookies().put(STATUS_COOKIE, cookie);
-    return retries;
-  }
-
-  /**
-   * Resets the authentication retry count in the session cookie.
-   * @param exchange the subject exchange
-   */
-  private void resetRetryCount(HttpServerExchange exchange) {
-    Cookie cookie = newCookie();
-    cookie.setValue("-1");
-    exchange.getResponseCookies().put(STATUS_COOKIE, cookie);
-  }
-
-  /**
-   * Creates a new cookie for the authentication retry count.
-   * @return cookie
-   */
-  private Cookie newCookie() {
-    Cookie cookie;
-    cookie = new CookieImpl(STATUS_COOKIE, "0");
-    cookie.setHttpOnly(true);
-    cookie.setSecure(true);
-    return cookie;
   }
 
   /**

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
@@ -52,10 +52,6 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
   private final InjectedValue<Profile> profile =
       new InjectedValue<>();
 
-  public Injector<Profile> getProfileInjector() {
-    return profile;
-  }
-
   private NoCasStatusCookie casStatusCookie;
 
   /**
@@ -68,10 +64,12 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
     this.contextPath = contextPath;
     this.authenticationService = authenticationService;
 
+    boolean casStatusCookieEnabled =
+    authenticationService.getConfiguration().isCasStatusCookieEnabled();
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("cookie is enabled: " + profile.getValue().isCasStatusCookieEnabled());
+      LOGGER.debug("cookie is enabled: " + casStatusCookieEnabled);
     }
-    if (profile.getValue().isCasStatusCookieEnabled()) {
+    if (casStatusCookieEnabled) {
       this.casStatusCookie = new CasStatusCookie();
     } else {
       this.casStatusCookie = new NoCasStatusCookie();

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
@@ -56,7 +56,7 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
     return profile;
   }
 
-  private CasStatusCookie casStatusCookie;
+  private NoCasStatusCookie casStatusCookie;
 
   /**
    * Constructs a new instance.
@@ -67,6 +67,15 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
       String contextPath, CasAuthenticationService authenticationService) {
     this.contextPath = contextPath;
     this.authenticationService = authenticationService;
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("cookie is enabled: " + profile.getValue().isCasStatusCookieEnabled());
+    }
+    if (profile.getValue().isCasStatusCookieEnabled()) {
+      this.casStatusCookie = new CasStatusCookie();
+    } else {
+      this.casStatusCookie = new NoCasStatusCookie();
+    }
   }
 
   /**

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationMechanism.java
@@ -23,14 +23,9 @@ import io.undertow.security.api.AuthenticationMechanism;
 import io.undertow.security.api.SecurityContext;
 import io.undertow.security.idm.Account;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.server.handlers.Cookie;
-import io.undertow.server.handlers.CookieImpl;
 import io.undertow.util.HttpString;
 
-import org.jboss.msc.inject.Injector;
-import org.jboss.msc.value.InjectedValue;
 import org.soulwing.cas.api.IdentityAssertion;
-import org.soulwing.cas.extension.Profile;
 import org.soulwing.cas.service.AuthenticationException;
 import org.soulwing.cas.service.Authenticator;
 import org.soulwing.cas.service.NoTicketException;
@@ -49,8 +44,6 @@ public class CasAuthenticationMechanism implements AuthenticationMechanism {
 
   private final String contextPath;
   private final CasAuthenticationService authenticationService;
-  private final InjectedValue<Profile> profile =
-      new InjectedValue<>();
 
   private NoCasStatusCookie casStatusCookie;
 

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationService.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasAuthenticationService.java
@@ -22,6 +22,7 @@ import org.jboss.msc.inject.Injector;
 import org.jboss.msc.value.InjectedValue;
 import org.soulwing.cas.service.AuthenticationService;
 import org.soulwing.cas.service.Authenticator;
+import org.soulwing.cas.service.Configuration;
 import org.soulwing.cas.service.ProxyCallbackResponse;
 
 /**
@@ -68,4 +69,11 @@ class CasAuthenticationService implements AuthenticationService {
     return delegate.getValue().handleProxyCallback(query);
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Configuration getConfiguration() {
+    return delegate.getValue().getConfiguration();
+  }
 }

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasStatusCookie.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasStatusCookie.java
@@ -7,7 +7,7 @@ import io.undertow.server.handlers.CookieImpl;
 /** Handles setting and counting the 'cas-status' cookie.
  * @author Stephan Fuhrmann
  *  */
-class CasStatusCookie {
+class CasStatusCookie extends NoCasStatusCookie {
     public static final String STATUS_COOKIE = "cas-status";
 
     static final int MAX_RETRIES = 2;
@@ -17,6 +17,7 @@ class CasStatusCookie {
      * @param exchange subject exchange
      * @return true if the retry count is exceeded
      */
+    @Override
     boolean isRetryCountExceeded(HttpServerExchange exchange) {
         return getRetryCount(exchange) >= MAX_RETRIES;
     }
@@ -26,7 +27,7 @@ class CasStatusCookie {
      * @param exchange subject exchange
      * @return current retry count
      */
-    int getRetryCount(HttpServerExchange exchange) {
+    private int getRetryCount(HttpServerExchange exchange) {
         int retries = 0;
 
         Cookie cookie = exchange.getRequestCookies().get(STATUS_COOKIE);
@@ -59,6 +60,7 @@ class CasStatusCookie {
      * Resets the authentication retry count in the session cookie.
      * @param exchange the subject exchange
      */
+    @Override
     void resetRetryCount(HttpServerExchange exchange) {
         Cookie cookie = newCookie();
         cookie.setValue("-1");

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasStatusCookie.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/CasStatusCookie.java
@@ -1,0 +1,79 @@
+package org.soulwing.cas.undertow;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.Cookie;
+import io.undertow.server.handlers.CookieImpl;
+
+/** Handles setting and counting the 'cas-status' cookie.
+ * @author Stephan Fuhrmann
+ *  */
+class CasStatusCookie {
+    public static final String STATUS_COOKIE = "cas-status";
+
+    static final int MAX_RETRIES = 2;
+
+    /**
+     * Gets the authentication retry count from a session cookie.
+     * @param exchange subject exchange
+     * @return true if the retry count is exceeded
+     */
+    boolean isRetryCountExceeded(HttpServerExchange exchange) {
+        return getRetryCount(exchange) >= MAX_RETRIES;
+    }
+
+    /**
+     * Gets the authentication retry count from a session cookie.
+     * @param exchange subject exchange
+     * @return current retry count
+     */
+    int getRetryCount(HttpServerExchange exchange) {
+        int retries = 0;
+
+        Cookie cookie = exchange.getRequestCookies().get(STATUS_COOKIE);
+        if (cookie == null) {
+            cookie = newCookie();
+        }
+        else {
+            try {
+                String value = cookie.getValue();
+                retries = Integer.parseInt(value) + 1;
+                if (retries < 0 || retries > MAX_RETRIES) {
+                    retries = MAX_RETRIES;
+                }
+            }
+            catch (NumberFormatException ex) {
+                retries = MAX_RETRIES;
+            }
+            finally {
+                cookie.setValue(Integer.toString(retries));
+            }
+        }
+
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        exchange.getResponseCookies().put(STATUS_COOKIE, cookie);
+        return retries;
+    }
+
+    /**
+     * Resets the authentication retry count in the session cookie.
+     * @param exchange the subject exchange
+     */
+    void resetRetryCount(HttpServerExchange exchange) {
+        Cookie cookie = newCookie();
+        cookie.setValue("-1");
+        exchange.getResponseCookies().put(STATUS_COOKIE, cookie);
+    }
+
+    /**
+     * Creates a new cookie for the authentication retry count.
+     * @return cookie
+     */
+    private Cookie newCookie() {
+        Cookie cookie;
+        cookie = new CookieImpl(STATUS_COOKIE, "0");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        return cookie;
+    }
+}

--- a/cas-subsystem/src/main/java/org/soulwing/cas/undertow/NoCasStatusCookie.java
+++ b/cas-subsystem/src/main/java/org/soulwing/cas/undertow/NoCasStatusCookie.java
@@ -1,0 +1,28 @@
+package org.soulwing.cas.undertow;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.Cookie;
+import io.undertow.server.handlers.CookieImpl;
+
+/** A dummy handler for the cas status cookie that is used when
+ * cookie handling is disabled.
+ * @author Stephan Fuhrmann
+ *  */
+class NoCasStatusCookie {
+
+    /**
+     * Gets the authentication retry count from a session cookie.
+     * @param exchange subject exchange
+     * @return true if the retry count is exceeded
+     */
+    boolean isRetryCountExceeded(HttpServerExchange exchange) {
+        return false;
+    }
+
+    /**
+     * Resets the authentication retry count in the session cookie.
+     * @param exchange the subject exchange
+     */
+    void resetRetryCount(HttpServerExchange exchange) {
+    }
+}

--- a/cas-subsystem/src/main/resources/org/soulwing/cas/extension/LocalDescriptions.properties
+++ b/cas-subsystem/src/main/resources/org/soulwing/cas/extension/LocalDescriptions.properties
@@ -32,6 +32,8 @@ ${subsystem.name}.cas-profile.allowed-proxy-chain.add=Adds an allowed proxy chai
 ${subsystem.name}.cas-profile.allowed-proxy-chain.remove=Removes an allowed proxy chain
 ${subsystem.name}.cas-profile.allowed-proxy-chain.proxies=List of allowed proxy URLs
 ${subsystem.name}.cas-profile.allowed-proxy-chain.proxies.proxy=Proxy URL
+${subsystem.name}.cas-profile.cas-status-cookie-enabled=Flag indicator whether to use a \
+  cookie to track the login attempt count
 ${subsystem.name}.cas-profile.attribute-transform=A transform to apply to an identity attribute
 ${subsystem.name}.cas-profile.attribute-transform.add=Adds an identity attribute transform definition
 ${subsystem.name}.cas-profile.attribute-transform.remove=Removes an an identity attribute transform definition

--- a/cas-subsystem/src/main/resources/schema/cas.xsd
+++ b/cas-subsystem/src/main/resources/schema/cas.xsd
@@ -54,6 +54,7 @@
     <xs:attribute name="clock-skew-tolerance" type="xs:long"/>
     <xs:attribute name="post-auth-redirect" type="xs:boolean"/>  
     <xs:attribute name="security-realm" type="xs:string"/>
+    <xs:attribute name="cas-status-cookie-enabled" type="xs:boolean" use="optional" default="true"/>
   </xs:complexType>
   
   <xs:simpleType name="AuthenticationProtocolType">


### PR DESCRIPTION
@ceharris 
As discussed, this is the reworked PR that allows to turn on/off whether the cas-status cookie should be used.
In our environment the host responds to multiple FQDNs which confuses the Cookie management and returns HTTP 403 errors occasionally.

I have tested the default case (enabled=true) as well as the special case (disabled=false). Wildfly-CLI knows about the new cookie flag and the README is updates.

Looking forward to your feedback.
